### PR TITLE
Don't add latency to client request

### DIFF
--- a/workers/worker.js
+++ b/workers/worker.js
@@ -1,7 +1,7 @@
 // window is not available in workers so we disable no-restricted-globals
 /* eslint-disable no-restricted-globals */
 
-async function handleRequest(request) {
+async function handleRequest(event, request) {
   const rMeth = request.method
   const rUrl = request.url
   const uAgent = request.headers.get("user-agent")
@@ -24,7 +24,7 @@ async function handleRequest(request) {
     body: JSON.stringify({ source: sourceKey, log_entry: logEntry }),
   }
 
-  const logflare = await fetch("https://logflare.app/api/logs", init)
+  event.waitUntil(fetch("https://logflare.app/api/logs", init))
 
   // console.log(cIP)
 
@@ -32,5 +32,5 @@ async function handleRequest(request) {
 }
 
 addEventListener("fetch", event => {
-  event.respondWith(handleRequest(event.request))
+  event.respondWith(handleRequest(event, event.request))
 })


### PR DESCRIPTION
Before this change, the worker was synchronously calling out to Logflare, adding latency to every request, blocking bytes from reaching the end user. By using `waitUntil()` to send the logflare request asynchronously, we can avoid adding any client-visible latency.

DISCLAIMER: I haven't tested this, I just edited the code online in Github.