### PR TITLE
Bug Fix : content-length header issue

### DIFF
--- a/workers/worker.js
+++ b/workers/worker.js
@@ -22,7 +22,7 @@ function buildLogEntry(request, response) {
     cfRay: request.headers.get("cf-ray"),
     cIP: request.headers.get("cf-connecting-ip"),
     statusCode: response.status,
-    contentLength: response.headers.get("content-legth"),
+    contentLength: response.headers.get("content-length"),
     cfCacheStatus: response.headers.get("cf-cache-status"),
     contentType: response.headers.get("content-type"),
     responseConnection: response.headers.get("connection"),


### PR DESCRIPTION
content-length header was misspelled due to which receiving empty length in logs.